### PR TITLE
Update README.md to reflect test/recipes structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ verifier:
 
 ### Directory Structure
 
-By default `kitchen-inspec` expects test to be in `test/integration/%suite%` directory structure (we use Chef as provisioner here):
+By default `kitchen-inspec` expects tests to be in the `test/recipes/%suite%` directory structure (we use Chef as provisioner here):
 
 ```
 .
@@ -52,7 +52,7 @@ By default `kitchen-inspec` expects test to be in `test/integration/%suite%` dir
 │   ├── default.rb
 │   └── nginx.rb
 └── test
-    └── integration
+    └── recipes
         └── default
             └── web_spec.rb
 ```
@@ -71,7 +71,7 @@ A complete profile is used here, including a custom inspec resource named `gordo
 │   ├── default.rb
 │   └── nginx.rb
 └── test
-    └── integration
+    └── recipes
         └── default
             ├── controls
             │   └── gordon.rb
@@ -79,6 +79,8 @@ A complete profile is used here, including a custom inspec resource named `gordo
             └── libraries
                 └── gordon_config.rb
 ```
+
+**Note:** If `kitchen-inspec` doesn't find a `test/recipes/%suite%` directory structure, it will look in `test/integration/%suite%`. 
 
 ### Combination with other testing frameworks
 


### PR DESCRIPTION
Recently, when starting a new project `kitchen-inspec` as my
verifier rather than `serverspec`, I noticed that it was looking in
`test/recipes/default` for tests. This directory _did_ exist because I
had created the cookbook with `chef generate cookbook`, but I had
written my initial test in `test/integration/default` out of habit.

In the commit history I noticed that d2b2742 changed the
`test_base_path` to `test/recipes` but it doesn't look like the
documentation was updated to reflect this.
