### PR TITLE
Adds support for kitchen-kubernetes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,6 @@ group :tools do
   gem "pry", "~> 0.10"
   gem "github_changelog_generator", "1.13.1"
 end
+
+# Pending release of kitchen-kubernetes
+gem "kitchen-kubernetes", git: 'https://github.com/coderanger/kitchen-kubernetes'

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "inspec", ">=0.34.0", "<2.0.0"
   spec.add_dependency "test-kitchen", "~> 1.6"
   spec.add_dependency "hashie", "~> 3.4"
+
+  spec.add_development_dependency "kitchen-kubernetes", "~> 1.0"
 end

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -194,6 +194,8 @@ module Kitchen
         # optional transport which is not in core test-kitchen
         elsif defined?(Kitchen::Transport::Dokken) && transport.is_a?(Kitchen::Transport::Dokken)
           runner_options_for_docker(transport_data)
+        elsif defined?(Kitchen::Transport::Kubernetes) && transport.is_a?(Kitchen::Transport::Kubernetes)
+          runner_options_for_kubernetes(transport_data)
         else
           raise Kitchen::UserError, "Verifier #{name} does not support the #{transport.name} Transport"
         end.tap do |runner_options|
@@ -276,6 +278,22 @@ module Kitchen
           "max_wait_until_ready" => kitchen[:max_wait_until_ready],
         }
         logger.debug "Connect to Container: #{opts['host']}"
+        opts
+      end
+
+      # Returns a configuration Hash that can be passed to a `Inspec::Runner`.
+      #
+      # @return [Hash] a configuration hash of string-based keys
+      # @api private
+      def runner_options_for_kubernetes(config_data)
+        opts = {
+          "backend" => "kubernetes",
+          "logger" => logger,
+          "pod" => config_data[:pod_id],
+          "container" => "default",
+          "kubectl_path" => config_data[:kubectl_path],
+        }
+        logger.debug "Connect to Pod: #{opts['pod']}"
         opts
       end
     end

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -24,6 +24,7 @@ require "logger"
 require "kitchen/verifier/inspec"
 require "kitchen/transport/ssh"
 require "kitchen/transport/winrm"
+require "kitchen/transport/kubernetes"
 
 describe Kitchen::Verifier::Inspec do
 
@@ -513,6 +514,44 @@ describe Kitchen::Verifier::Inspec do
         .and_return(runner)
 
       verifier.call(hostname: "win.dows", port: 123)
+    end
+  end
+
+  context "with a kubernetes transport" do
+    let(:transport_config) do
+      {
+        kubectl_path: "./kubectl"
+      }
+    end
+
+    let(:transport) do
+      Kitchen::Transport::Kubernetes.new(transport_config)
+    end
+
+    let(:runner) do
+      instance_double("Inspec::Runner")
+    end
+
+    before do
+      allow(runner).to receive(:add_target)
+      allow(runner).to receive(:run).and_return 0
+    end
+
+    it "constructs a Inspec::Runner using transport config data" do
+      config[:host] = "192.168.56.40"
+      config[:port] = 22
+
+      expect(Inspec::Runner).to receive(:new)
+        .with(
+          hash_including(
+            "backend" => "kubernetes",
+            "pod" => "asdf1234",
+            "kubectl_path" => "./kubectl"
+          )
+        )
+        .and_return(runner)
+
+      verifier.call(pod_id: "asdf1234")
     end
   end
 


### PR DESCRIPTION
Depends on https://github.com/chef/train/pull/205 for the actual backend support, though they can be merged in either order as kitchen-kubernetes is still in pre-release testing right now.