### PR TITLE
Add proxy_command transport setting to inspec runner

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -239,6 +239,7 @@ module Kitchen
           "max_wait_until_ready" => kitchen[:max_wait_until_ready],
           "compression" => kitchen[:compression],
           "compression_level" => kitchen[:compression_level],
+          "proxy_command" => config[:proxy_command],
         }
         opts["key_files"] = kitchen[:keys] unless kitchen[:keys].nil?
         opts["password"] = kitchen[:password] unless kitchen[:password].nil?

--- a/spec/kitchen/verifier/inspec_spec.rb
+++ b/spec/kitchen/verifier/inspec_spec.rb
@@ -253,6 +253,7 @@ describe Kitchen::Verifier::Inspec do
     it "constructs a Inspec::Runner using transport config data and state" do
       config[:sudo] = "jellybeans"
       config[:sudo_command] = "allyourbase"
+      config[:proxy_command] = "gateway"
 
       expect(Inspec::Runner).to receive(:new)
         .with(
@@ -272,7 +273,8 @@ describe Kitchen::Verifier::Inspec do
             "max_wait_until_ready" => 42,
             "compression" => "maxyo",
             "compression_level" => "pico",
-            "key_files" => ["/backstage/pass"]
+            "key_files" => ["/backstage/pass"],
+            "proxy_command" => "gateway"
           )
         )
         .and_return(runner)


### PR DESCRIPTION
Allow setting for proxy_command that was added to train here: https://github.com/chef/train/pull/227

Example config:
```
verifier:
  proxy_command: ssh user@1.2.3.4 -W %h:%p 
```

My main use case for this is we use a bastion host and therefor I need to be able to jump through the appropriate hoop to reach my instance which I can do with the above example.