### PR TITLE
Update ruby version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
     - master
 language: ruby
 cache: bundler
-dist: trusty
 services:
   - docker
 bundler_args: "--without integration guard tools"
@@ -15,27 +14,28 @@ before_install:
   - bundle --version
 matrix:
   include:
-  - rvm: 2.3.6
-  - rvm: 2.4.3
+  - rvm: 2.3.7
+  - rvm: 2.4.4
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='default profile contains_inspec'
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='backwards'
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='duplicates'
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='supermarket'
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     bundler_args: "--without guard tools"
     script: bundle exec rake $SUITE
     env: SUITE="test:integration" OS='attributes-inline attributes-file'
+  - rvm: 2.5.1
   - rvm: ruby-head
   allow_failures:
   - rvm: ruby-head


### PR DESCRIPTION
Use the latest patch releases, add 2.5.1, and remove the dist setting of
trusty which is the default now

Signed-off-by: Tim Smith <tsmith@chef.io>