### PR TITLE
Remove workaround for Ruby < 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@
 source "https://rubygems.org"
 gemspec
 
-# pin dependency for Ruby 1.9.3 since bundler is not
-# detecting that net-ssh 3 does not work with 1.9.3
-if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("1.9.3")
-  gem "net-ssh", "~> 2.9"
-end
-
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
   gem "json", "< 2.0"
   gem "rack", "< 2.0"


### PR DESCRIPTION
The gem requires 2.1 anyways

Signed-off-by: Tim Smith <tsmith@chef.io>