### PR TITLE
Switch to inspec-core

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.1.0"
-  spec.add_dependency "inspec", ">=0.34.0", "<3.0.0"
+  spec.add_dependency "inspec-core", ">=2.1", "<3.0"
   spec.add_dependency "test-kitchen", "~> 1.6"
   spec.add_dependency "hashie", "~> 3.4"
 end


### PR DESCRIPTION
Avoid pulling in the world with inspec. This drops 15 deps from the bundle install.

Signed-off-by: Tim Smith <tsmith@chef.io>