### PR TITLE
add new transport support - docker_cli.

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -304,6 +304,20 @@ module Kitchen
         }
         opts
       end
+
+      # Returns a configuration Hash that can be passed to a `Inspec::Runner`.
+      #
+      # @return [Hash] a configuration hash of string-based keys
+      # @api private
+      def runner_options_for_dockercli(config_data)
+        opts = {
+          "backend" => "docker",
+          "logger" => logger,
+          "host" => config_data[:container_id],
+        }
+        logger.debug "Connect to Container: #{opts['host']}"
+        opts
+      end
     end
   end
 end


### PR DESCRIPTION
this pull request add support for test-kitchen docker_cli transport (https://github.com/marcy-terui/kitchen-docker_cli)

Signed-off-by: chrisLeeTW protosschris.tech@gmail.com