### PR TITLE
Slim the files that ship with the Gem

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "kitchen/verifier/inspec_version"
-require "English"
 
 Gem::Specification.new do |spec|
   spec.name          = "kitchen-inspec"
@@ -16,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/inspec/kitchen-inspec"
 
   spec.files         = `git ls-files -z`.split("\x0")
-    .reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
+    .grep(/LICENSE|^CHANGELOG|^lib|^bin/)
+  spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.1.0"


### PR DESCRIPTION
Avoid shipping berksfile, Gemfile, the gemspec, and others. This will slim down the size of ChefDK by 25k

Signed-off-by: Tim Smith <tsmith@chef.io>