### PR TITLE
Allow InSpec 3.0

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -15,12 +15,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/inspec/kitchen-inspec"
 
   spec.files         = `git ls-files -z`.split("\x0")
-    .grep(/LICENSE|^CHANGELOG|^lib|^bin/)
+    .grep(/LICENSE|^lib|^bin/)
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.1.0"
-  spec.add_dependency "inspec", ">=0.34.0", "<3.0.0"
+  spec.add_dependency "inspec", ">=0.34.0", "<4.0.0"
   spec.add_dependency "test-kitchen", "~> 1.6"
   spec.add_dependency "hashie", "~> 3.4"
 end


### PR DESCRIPTION
This allows us to use this driver with the latest inspec. I also remove d the changelog from the gem which aligns with our other gems.

Signed-off-by: Tim Smith <tsmith@chef.io>