### PR TITLE
Use only defined paths if specified (Fixes #216)

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -182,8 +182,9 @@ module Kitchen
       # @return [Array<String>] array of suite directories or remote urls
       # @api private
       def collect_tests
-        # get local tests and get run list of profiles
-        (local_suite_files + resolve_config_inspec_tests).compact.uniq
+        # get run list of profiles or fall back to local tests
+        return resolve_config_inspec_tests.uniq if resolve_config_inspec_tests
+        local_suite_files
       end
 
       # Returns a configuration Hash that can be passed to a `Inspec::Runner`.


### PR DESCRIPTION
In reference to #216, this would be option 2 where default test directory is ignored if test paths are specified using `inspec_tests`.
