### PR TITLE
Update to allow Test Kitchen 2.0 and InSpec 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 Berksfile.lock
 .kitchen
+*.gem

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  spec.add_dependency "inspec", ">=1.47.0", "<4.0.0"
-  spec.add_dependency "test-kitchen", "~> 1.6"
+  spec.add_dependency "inspec", ">= 1.47", "< 5.0"
+  spec.add_dependency "test-kitchen", ">= 1.6", "< 3"
   spec.add_dependency "hashie", "~> 3.4"
 end


### PR DESCRIPTION
These will ship in DK 4 so we need to get a version of kitchen-inspec out that supports them

Signed-off-by: Tim Smith <tsmith@chef.io>