### PR TITLE
Add relative path support for the GIT fetcher

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -184,7 +184,7 @@ module Kitchen
             # leave it alone so it can default to resolving to the Supermarket.
             unless test_item.keys == [:name]
               type_keys = [:path, :url, :git, :compliance, :supermarket]
-              git_keys = [:branch, :tag, :ref]
+              git_keys = [:branch, :tag, :ref, :relative_path]
               supermarket_keys = [:supermarket_url]
               test_item.delete_if { |k, v| !(type_keys + git_keys + supermarket_keys).include?(k) }
             end


### PR DESCRIPTION
Adds support with TestKitchen for InSpec's recently released relative path feature.
https://github.com/inspec/inspec/pull/4217

Lets you do something like this:
```yaml
suites:
  - name: default
    run_list:
      - recipe[test::default]
    verifier:
      inspec_tests:
        - test/integration/default
        - name: my_other_cookbook
          git: git@git.mycompany.net:TEAM/chef-cookbooks/my_other_cookbook.git
          tag: master
          relative_path: test/integration/default
```