### PR TITLE
expeditor: Rubygems list should be an array, not a hash

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -6,8 +6,7 @@ slack:
 
 # This publish is triggered by the `built_in:publish_rubygems` artifact_action.
 rubygems:
-  - kitchen-inspec:
-      gemspec_path: ./ # Just here to force this to be a hash
+  - kitchen-inspec
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

### Description

Fixes #238 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG