### PR TITLE
Add setting to load Inspec plugins for additional functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ You can also define your inputs in external files. Adapt your `.kitchen.yml` to 
 
 ### Use inspec plugins
 
-By default, the verified does not load Inspec plugins like additional inputs. You can activate loading the same plugins as on normal Inspec invocations:
+By default, the verifier does not load Inspec plugins such as additional input plugins. You can activate loading the same plugins as on normal Inspec invocations:
 
 ```yaml
     verifier:

--- a/README.md
+++ b/README.md
@@ -266,6 +266,15 @@ You can also define your inputs in external files. Adapt your `.kitchen.yml` to 
         - test/integration/profile-attribute.yml
 ```
 
+### Use inspec plugins
+
+By default, the verified does not load Inspec plugins like additional inputs. You can activate loading the same plugins as on normal Inspec invocations:
+
+```yaml
+    verifier:
+      load_plugins: true
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -26,6 +26,8 @@ require "uri"
 require "pathname"
 require "hashie"
 
+require "inspec/plugin/v2"
+
 module Kitchen
   module Verifier
     # InSpec verifier for Kitchen.
@@ -36,6 +38,7 @@ module Kitchen
       plugin_version Kitchen::Verifier::INSPEC_VERSION
 
       default_config :inspec_tests, []
+      default_config :load_plugins, false
 
       # A lifecycle method that should be invoked when the object is about
       # ready to be used. A reference to an Instance is required as
@@ -79,6 +82,13 @@ module Kitchen
 
         # initialize runner
         runner = ::Inspec::Runner.new(opts)
+
+        # load plugins
+        if config[:load_plugins]
+          v2_loader = ::Inspec::Plugin::V2::Loader.new
+          v2_loader.load_all
+          v2_loader.exit_on_load_error
+        end
 
         # add each profile to runner
         tests = collect_tests


### PR DESCRIPTION
### Description

Currently, kitchen-inspec does not support InSpec plugins, as it directly calls the Runner. This PR implements a setting to enable loading of plugins (like additional inputs). The setting defaults to `false` to not break compatibility.

### Issues Resolved

No filed issue so far.

### Check List

- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG