### PR TITLE
Require InSpec 2.2.64+ to support plugin v2

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  spec.add_dependency "inspec", ">= 1.47", "< 5.0"
+  spec.add_dependency "inspec", ">= 2.2.64", "< 5.0" # 2.2.64 is required for plugin v2 support
   spec.add_dependency "test-kitchen", ">= 1.6", "< 3"
   spec.add_dependency "hashie", "~> 3.4"
 end


### PR DESCRIPTION
Thanks for pointing this out @satyanash. This fixes https://github.com/inspec/kitchen-inspec/issues/253

Signed-off-by: Tim Smith <tsmith@chef.io>