### PR TITLE
Fix call with deprecated options hash

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -94,7 +94,7 @@ module Kitchen
         tests = collect_tests
         profile_ctx = nil
         tests.each do |target|
-          profile_ctx = runner.add_target(target, opts)
+          profile_ctx = runner.add_target(target)
         end
 
         profile_ctx ||= []


### PR DESCRIPTION
### Description

Kitchen-inspec supplies an `opts` argument to InSpec which was removed pre-1.0.0 there. The InSpec source even states:

`@params _opts [Hash] Unused, but still here to avoid breaking kitchen-inspec`

see https://github.com/inspec/inspec/blob/master/lib/inspec/runner.rb#L193

### Issues Resolved

Trivial code clean-up only

### Check List

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG