### PR TITLE
Add ability to disable input caching in InSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,13 @@ By default, the verifier does not load Inspec plugins such as additional input p
       load_plugins: true
 ```
 
+When using plugins, please be aware that input values get cached. If you want to re-evaluate these values for every suite, you can deactivate the cache:
+
+```yaml
+    verifier:
+      cache_inputs: false
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -89,7 +89,9 @@ module Kitchen
           v2_loader.load_all
           v2_loader.exit_on_load_error
 
-          ::Inspec::InputRegistry.instance.cache_inputs = !!config[:cache_inputs] if config[:cache_inputs]
+          if ::Inspec::InputRegistry.instance.respond_to?(:cache_inputs=) && config[:cache_inputs]
+            ::Inspec::InputRegistry.instance.cache_inputs = !!config[:cache_inputs]
+          end
         end
 
         # add each profile to runner

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -88,6 +88,8 @@ module Kitchen
           v2_loader = ::Inspec::Plugin::V2::Loader.new
           v2_loader.load_all
           v2_loader.exit_on_load_error
+
+          ::Inspec::InputRegistry.instance.cache_inputs = !!config[:cache_inputs] if config[:cache_inputs]
         end
 
         # add each profile to runner


### PR DESCRIPTION
### Description

This allows deactivating the input caching in InSpec to avoid values from previous suites to persist into follow-up runs.

For a detailed explanation see [InSpec PR #5211](https://github.com/inspec/inspec/pull/5211).

### Issues Resolved

See [InSpec PR #5211](https://github.com/inspec/inspec/pull/5211).

### Check List

- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG