### PR TITLE
Declare kitchen-inspec to be run serially

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
   spec.add_dependency "inspec", ">= 2.2.64", "< 5.0" # 2.2.64 is required for plugin v2 support
-  spec.add_dependency "test-kitchen", ">= 1.6", "< 3"
+  spec.add_dependency "test-kitchen", ">= 2.7", "< 3" # 2.7 introduced no_parallel_for for verifiers
   spec.add_dependency "hashie", "~> 3.4"
 end

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -37,6 +37,11 @@ module Kitchen
       kitchen_verifier_api_version 1
       plugin_version Kitchen::Verifier::INSPEC_VERSION
 
+      # Chef InSpec is based on RSpec, which is not thread safe
+      # (https://github.com/rspec/rspec-core/issues/1254)
+      # Tell test kitchen not to multithread the verify step
+      no_parallel_for :verify
+
       default_config :inspec_tests, []
       default_config :load_plugins, false
 
@@ -304,7 +309,6 @@ module Kitchen
           "connection_retry_sleep" => kitchen[:connection_retry_sleep],
           "max_wait_until_ready" => kitchen[:max_wait_until_ready],
         }
-        
       end
 
       # Returns a configuration Hash that can be passed to a `Inspec::Runner`.
@@ -339,7 +343,6 @@ module Kitchen
           "backend" => "local",
           "logger" => logger,
         }
-        
       end
 
       # Returns a configuration Hash that can be passed to a `Inspec::Runner`.


### PR DESCRIPTION
### Description

Informs test-kitchen that the `inspec` verifier should not be run multithreaded.  This is because Chef InSpec is not thread-safe, due to RSpec not being thread safe; when run multithreaded, random test failures or test count inaccuracies can occur, as well as random `No method each for nil::NilClass` errors. See #167 and https://github.com/test-kitchen/test-kitchen/issues/1530 for details.

~PR set as draft until https://github.com/test-kitchen/test-kitchen/pull/1678 merges and the TK version is bumped, because this needs to have an updated version pin against test-kitchen in the kitchen-inspec gemspec.~ TK 2.7.0 includes the feature.

### Issues Resolved

Closes #167

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG