### PR TITLE
Load plugins earlier; load plugins by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,14 +268,14 @@ You can also define your inputs in external files. Adapt your `.kitchen.yml` to 
 
 ### Use inspec plugins
 
-By default, the verifier does not load Inspec plugins such as additional input plugins. You can activate loading the same plugins as on normal Inspec invocations:
+By default, the verifier loads Inspec plugins such as additional Reporter or Input plugins. This adds a small delay as the system scans for plugins. If you know you are not using special Reporters or Inputs, you can disable plugin loading:
 
 ```yaml
     verifier:
-      load_plugins: true
+      load_plugins: false
 ```
 
-When using plugins, please be aware that input values get cached. If you want to re-evaluate these values for every suite, you can deactivate the cache:
+When using Input plugins, please be aware that input values get cached between suites. If you want to re-evaluate these values for every suite, you can deactivate the cache:
 
 ```yaml
     verifier:

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -43,7 +43,7 @@ module Kitchen
       no_parallel_for :verify
 
       default_config :inspec_tests, []
-      default_config :load_plugins, false
+      default_config :load_plugins, true
 
       # A lifecycle method that should be invoked when the object is about
       # ready to be used. A reference to an Instance is required as

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -85,9 +85,6 @@ module Kitchen
         ::Inspec::Log.init(STDERR)
         ::Inspec::Log.level = Kitchen::Util.from_logger_level(logger.level)
 
-        # initialize runner
-        runner = ::Inspec::Runner.new(opts)
-
         # load plugins
         if config[:load_plugins]
           v2_loader = ::Inspec::Plugin::V2::Loader.new
@@ -98,6 +95,9 @@ module Kitchen
             ::Inspec::InputRegistry.instance.cache_inputs = !!config[:cache_inputs]
           end
         end
+
+        # initialize runner
+        runner = ::Inspec::Runner.new(opts)
 
         # add each profile to runner
         tests = collect_tests


### PR DESCRIPTION
### Description

This change tells the Chef InSpec plugin system to scan for installed plugins before creating the InSpec Runner. This is important, because the Runner validates which Reports are valid based on the known plugins at the time. 

In addition, this change changes the default value for the `load_plugins` config option to be `true`.  Users are routinely bitten by this option, and as we move more functionality into plugins, the default should clearly be to load plugins by default, unless told not to for performance reasons, in which case we assume the user knows what they are doing.

Updated the README accordingly.

### Issues Resolved

Fixes https://github.com/inspec/inspec/issues/5102

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG