### PR TITLE
enabling default backend cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ When using Input plugins, please be aware that input values get cached between s
       cache_inputs: false
 ```
 
+ Default for backend cache is enabled
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,12 @@ When using Input plugins, please be aware that input values get cached between s
       cache_inputs: false
 ```
 
- Default for backend cache is enabled
+ Backend cache is enabled by default,if you want to disable backend cache you can do:
+
+ ```yaml
+     verifier:
+       backend_cache: false
+ ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,9 @@ When using Input plugins, please be aware that input values get cached between s
       cache_inputs: false
 ```
 
- Backend cache is enabled by default,if you want to disable backend cache you can do:
+ ### Chef InSpec Backend Cache
+
+ Chef InSpec uses a cache when executing commands and accessing files on the remote target. The cache is enabled by default. To disable the cache:
 
  ```yaml
      verifier:

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -44,6 +44,7 @@ module Kitchen
 
       default_config :inspec_tests, []
       default_config :load_plugins, true
+      default_config :backend_cache, true
 
       # A lifecycle method that should be invoked when the object is about
       # ready to be used. A reference to an Instance is required as


### PR DESCRIPTION
Signed-off-by: Pranay Singh <i5singh.pranay@gmail.com>

### Description
kitchen-inspec the default for backend_cache is disabled so running test cases (against a windows 2016 instance) without cache enabled is taking more time than usual.

Adding backend_cache: true (enabled) will improve performance. 

### Issues Resolved

- https://github.com/inspec/kitchen-inspec/issues/212

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG