### PR TITLE
Loosen the hashie dep to allow 4.x

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
   spec.add_dependency "inspec", ">= 2.2.64", "< 5.0" # 2.2.64 is required for plugin v2 support
   spec.add_dependency "test-kitchen", ">= 2.7", "< 3" # 2.7 introduced no_parallel_for for verifiers
-  spec.add_dependency "hashie", "~> 3.4"
+  spec.add_dependency "hashie", ">= 3.4", "<= 4.0"
 end


### PR DESCRIPTION
Signed-off-by: Nikhil Gupta nikhilgupta2102@gmail.com

**Description**
Enhancement to loosen the hashie gem dependencies to allow 4.x which resolves warnings on ruby 2.6 and 2.7

### Issues Resolved
**248** - Allow for hashie 4.x
[https://github.com/inspec/kitchen-inspec/issues/248](url)

### Check List


- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
