### PR TITLE
Load plugins prior to InSpec config validation

### DIFF
--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -86,10 +86,10 @@ module Kitchen
         # setup Inspec
         ::Inspec::Log.init(STDERR)
         ::Inspec::Log.level = Kitchen::Util.from_logger_level(logger.level)
+        load_plugins # Must load plugins prior to config validation
         inspec_config = ::Inspec::Config.new(opts)
 
         # handle plugins
-        load_plugins
         setup_plugin_config(inspec_config)
 
         # initialize runner


### PR DESCRIPTION

Turns out that initializing the InSpec Config object causes it to examine the plugin list, so any unrecognized plugins will throw an exception.

Fixes #273


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG