### PR TITLE
Add support for waivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ You can also define your inputs in external files. Adapt your `kitchen.yml` to p
 
 ## Use waivers with your InSpec profiles
 
-You can define your waivers in external files:
+You can define your [waivers](https://docs.chef.io/inspec/waivers/) in external files:
 
 ```yaml
     verifier:
@@ -274,7 +274,7 @@ You can define your waivers in external files:
         - path: test/integration/attributes
       input_files:
         - test/integration/profile-attribute.yml
-      waivers:
+      waiver_files:
         - test/integration/control-waiver-01.yml
 ```
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -69,6 +69,12 @@ suites:
         - test/integration/inputs-file
       input_files:
         - test/integration/profile-inputs.yml
+  - name: with_waivers
+    verifier:
+      inspec_tests:
+        - test/integration/with_waivers
+      waiver_files:
+        - test/integration/with_waivers.yml
   # before you are able to use the compliance plugin, you need to run
   # insecure is only required if you use self-signed certificates
   # $ inspec compliance login https://compliance.test --user admin --insecure --token ''

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -80,8 +80,9 @@ module Kitchen
         opts = runner_options(instance.transport, state, instance.platform.name, instance.suite.name)
         logger.debug "Options #{opts.inspect}"
 
-        # add inputs
+        # add inputs and waivers
         setup_inputs(opts, config)
+        setup_waivers(opts, config)
 
         # setup Inspec
         ::Inspec::Log.init(STDERR)
@@ -114,6 +115,11 @@ module Kitchen
       end
 
       private
+
+      def setup_waivers(opts, config)
+        # InSpec expects the singular inflection
+        opts[:waiver_file] = config[:waiver_files] || []
+      end
 
       def setup_inputs(opts, config)
         inspec_version = Gem::Version.new(::Inspec::VERSION)

--- a/test/integration/with_waivers/controls/test.rb
+++ b/test/integration/with_waivers/controls/test.rb
@@ -1,0 +1,12 @@
+control 'passing-test' do
+  describe 'true' do
+    it { should cmp 'true' }
+  end
+end
+
+
+control 'failing-test' do
+  describe 'false' do
+    it { should cmp 'true' }
+  end
+end

--- a/test/integration/with_waivers/files/waivers.yml
+++ b/test/integration/with_waivers/files/waivers.yml
@@ -1,0 +1,3 @@
+failing-test:
+  justification: "expected to fail"
+  run: false

--- a/test/integration/with_waivers/inspec.yml
+++ b/test/integration/with_waivers/inspec.yml
@@ -1,0 +1,8 @@
+name: with_waivers
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: All Rights Reserved
+summary: An InSpec Compliance Profile
+version: 0.1.0


### PR DESCRIPTION
### Description

Waiver file support was claimed, but in fact had not been implemented. This implements it, renaming the config key to be consistent, and adds a test case.

### Issues Resolved

Fixes #290 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG