### PR TITLE
Use InSpec 5 for Now

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  spec.add_dependency "inspec", ">= 2.2.64", "< 7.0" # 2.2.64 is required for plugin v2 support
+  spec.add_dependency "inspec", ">= 2.2.64", "< 6.0" # 2.2.64 is required for plugin v2 support
   spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
   spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
 end


### PR DESCRIPTION
### Description

Last year, we allowed InSpec 6 for testing and integration purposes. However, Progress product is not yet ready to release InSpec 6 support for Test Kitchen, wishing to delay that support for a future date. With that in mind, th pin on InSpec is being pulled back to "< 6.0", restricting InSpec to v5.

As InSpec 6 is not yet released, this is not a breaking change. 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG