### PR TITLE
CHEF-12879 Kitchen integration with InSpec 6 

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,40 @@ When using Input plugins, please be aware that input values get cached between s
        backend_cache: false
  ```
 
+### Configure Chef License Key and Licensing Service URL for Inspec version 6 or higher
+
+To configure Chef License Key for Chef InSpec, modify your `kitchen.yml` in the following way:
+
+```yaml
+    verifier:
+      chef_license_key: LICENSE_KEY_VALUE
+```
+
+Additionally, If you are using InSpec with Local Licensing Service, you can configure `chef_license_server` by providing the Licensing Service URL.
+
+
+```yaml
+    verifier:
+      chef_license_key: LICENSE_KEY_VALUE
+      chef_license_server: https://test-local-licensing-service-url
+```
+
+Or
+
+For avoiding a single point of failure, it is possible to set up multiple local licensing services. To configure them for InSpec, modify your `kitchen.yml` as follows:
+
+```yaml
+    verifier:
+      chef_license_key: LICENSE_KEY_VALUE
+      chef_license_server:
+        - https://test-local-licensing-service-url-1
+        - https://test-local-licensing-service-url-2
+        - https://test-local-licensing-service-url-3
+```
+
+<!-- TODO Insert Link to right document -->
+See the [Chef License documentation](/license/) for more information about Chef licensing.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,10 @@ To configure Chef License Key for Chef InSpec, modify your `kitchen.yml` in the 
       chef_license_key: LICENSE_KEY_VALUE
 ```
 
+Or
+
+It could also be configured by setting environment variable `CHEF_LICENSE_KEY` with the license key string.
+
 Additionally, If you are using InSpec with Local Licensing Service, you can configure `chef_license_server` by providing the Licensing Service URL.
 
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ For avoiding a single point of failure, it is possible to set up multiple local 
         - https://test-local-licensing-service-url-3
 ```
 
+It could also be configured by setting environment variable `CHEF_LICENSE_SERVER` with the Licensing Service URL(s).
+
 <!-- TODO Insert Link to right document -->
 See the [Chef License documentation](/license/) for more information about Chef licensing.
 

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  # Version upgrade to InSpec 6
-  spec.add_dependency "inspec", "~> 6.0"
+  spec.add_dependency "inspec", ">= 2.2.64", "< 7.0" # 2.2.64 is required for plugin v2 support & InSpec 6 included
   spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
   spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
 end

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  spec.add_dependency "inspec", ">= 2.2.64", "< 6.0" # 2.2.64 is required for plugin v2 support
+  # Version upgrade to InSpec 6
+  spec.add_dependency "inspec", "~> 6.0"
   spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
   spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
 end

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -121,9 +121,8 @@ module Kitchen
       def setup_chef_license_config(opts, config)
         # Pass chef_license_key to inspec if it is set
         # Pass chef_license_server to inspec if it is set
-        chef_license_key = config[:chef_license_key] || ENV["CHEF_LICENSE_KEY"]
-        opts[:chef_license_key] = chef_license_key if chef_license_key
-        opts[:chef_license_server] = config[:chef_license_server] if config[:chef_license_server]
+        opts[:chef_license_key] = config[:chef_license_key] || ENV["CHEF_LICENSE_KEY"]
+        opts[:chef_license_server] = config[:chef_license_server] || ENV["CHEF_LICENSE_SERVER"]
       end
 
       def setup_waivers(opts, config)

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -83,6 +83,8 @@ module Kitchen
         # add inputs and waivers
         setup_inputs(opts, config)
         setup_waivers(opts, config)
+        # Configure Chef License Key and URL through kitchen
+        setup_chef_license_config(opts, config)
 
         # setup Inspec
         ::Inspec::Log.init(STDERR)
@@ -115,6 +117,14 @@ module Kitchen
       end
 
       private
+
+      def setup_chef_license_config(opts, config)
+        # Pass chef_license_key to inspec if it is set
+        # Pass chef_license_server to inspec if it is set
+        chef_license_key = config[:chef_license_key] || ENV["CHEF_LICENSE_KEY"]
+        opts[:chef_license_key] = chef_license_key if chef_license_key
+        opts[:chef_license_server] = config[:chef_license_server] if config[:chef_license_server]
+      end
 
       def setup_waivers(opts, config)
         # InSpec expects the singular inflection


### PR DESCRIPTION

### Description
- Upgrade Inspec version to major version 6
- Enable the ability to set chef_license_key using Kitchen
- Enable the ability to set chef_license_server using Kitchen

Via Kitchen **kitchen.yaml**
To configure verifier block with `chef_license_key` :
```
verifier:
  name: inspec
  chef_license_key: LICENSE_KEY
```

To configure verifier block with `chef_license_server` :

**Multiple URLS**
```
verifier:
  name: inspec
  chef_license_key: LICENSE_KEY
  chef_license_server:
    - https://test-url-1
    - https://test-url-2
```
Or

**Single URL**
```
verifier:
  name: inspec
  chef_license_key: LICENSE_KEY
  chef_license_server: https://test-url-1
```

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG