### PR TITLE
Fetch the license_key from the provisioner config as well.

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|Gemfile|kitchen-inspec.gemspec|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  spec.add_dependency "inspec", ">= 2.2.64", "< 7.0" # 2.2.64 is required for plugin v2 support & InSpec 6 included
+  spec.add_dependency "inspec", "~> 6.0" # 6.0 is the first version with the licensing changes.
   #spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
   spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
 end

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|Gemfile|kitchen-inspec.gemspec|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  spec.add_dependency "inspec", "~> 6.0" # 6.0 is the first version with the licensing changes.
-  #spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
+  spec.add_dependency "inspec", "~> 6.0" # for RC1 release 6.0 and the above has the licensing changes.
   spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
 end

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -121,8 +121,13 @@ module Kitchen
       def setup_chef_license_config(opts, config)
         # Pass chef_license_key to inspec if it is set
         # Pass chef_license_server to inspec if it is set
-        opts[:chef_license_key] = config[:chef_license_key] || ENV["CHEF_LICENSE_KEY"]
-        opts[:chef_license_server] = config[:chef_license_server] || ENV["CHEF_LICENSE_SERVER"]
+        p = instance.provisioner
+        opts[:chef_license_key] = config[:chef_license_key] ||
+          ENV["CHEF_LICENSE_KEY"] ||
+          (p.chef_license_key if p.respond_to?(:chef_license_key))
+        opts[:chef_license_server] = config[:chef_license_server] ||
+          ENV["CHEF_LICENSE_SERVER"] ||
+          (p.chef_license_server if p.respond_to?(:chef_license_server))
       end
 
       def setup_waivers(opts, config)


### PR DESCRIPTION
### Description

[Please describe what this change achieves]
- Pinning the inspec to > 6 since it is required for the RC1 release
- Try to get the license key defined on the provisioner as well if all the other method fails.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG