### PR TITLE
CHEF-20340 - Fix dependency conflict with hashie for chef-zero-15.0.11 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 source "https://rubygems.org"
 gemspec
 
+gem "chef-test-kitchen-enterprise", git: "https://github.com/chef/chef-test-kitchen-enterprise", branch: "rebranding_change"
+
 group :guard do
   gem "guard-rspec",    require: nil
   gem "guard-rubocop",  require: nil

--- a/README.md
+++ b/README.md
@@ -321,6 +321,10 @@ To configure Chef License Key for Chef InSpec, modify your `kitchen.yml` in the 
       chef_license_key: LICENSE_KEY_VALUE
 ```
 
+Or
+
+It could also be configured by setting environment variable `CHEF_LICENSE_KEY` with the license key string.
+
 Additionally, If you are using InSpec with Local Licensing Service, you can configure `chef_license_server` by providing the Licensing Service URL.
 
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ For avoiding a single point of failure, it is possible to set up multiple local 
         - https://test-local-licensing-service-url-3
 ```
 
+It could also be configured by setting environment variable `CHEF_LICENSE_SERVER` with the Licensing Service URL(s).
+
 <!-- TODO Insert Link to right document -->
 See the [Chef License documentation](/license/) for more information about Chef licensing.
 

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
   spec.add_dependency "inspec", ">= 2.2.64", "< 7.0" # 2.2.64 is required for plugin v2 support & InSpec 6 included
-  spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
+  #spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
   spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
 end

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/inspec/kitchen-inspec"
 
-  spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
+  spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|Gemfile|kitchen-inspec.gemspec|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
   spec.add_dependency "inspec", ">= 2.2.64", "< 7.0" # 2.2.64 is required for plugin v2 support & InSpec 6 included

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
   spec.add_dependency "inspec", "~> 6.0" # for RC1 release 6.0 and the above has the licensing changes.
-  spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
+  spec.add_dependency "hashie", ">= 3.4", "< 5.0"
 end

--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
-  # Version upgrade to InSpec 6
-  spec.add_dependency "inspec", "~> 6.0"
+  spec.add_dependency "inspec", ">= 2.2.64", "< 7.0" # 2.2.64 is required for plugin v2 support & InSpec 6 included
   spec.add_dependency "test-kitchen", ">= 2.7", "< 4" # 2.7 introduced no_parallel_for for verifiers
   spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
 end

--- a/lib/kitchen/verifier/inspec.rb
+++ b/lib/kitchen/verifier/inspec.rb
@@ -121,9 +121,8 @@ module Kitchen
       def setup_chef_license_config(opts, config)
         # Pass chef_license_key to inspec if it is set
         # Pass chef_license_server to inspec if it is set
-        chef_license_key = config[:chef_license_key] || ENV["CHEF_LICENSE_KEY"]
-        opts[:chef_license_key] = chef_license_key if chef_license_key
-        opts[:chef_license_server] = config[:chef_license_server] if config[:chef_license_server]
+        opts[:chef_license_key] = config[:chef_license_key] || ENV["CHEF_LICENSE_KEY"]
+        opts[:chef_license_server] = config[:chef_license_server] || ENV["CHEF_LICENSE_SERVER"]
       end
 
       def setup_waivers(opts, config)


### PR DESCRIPTION
### Description
Resolving a dependency conflict in hashie gem to ensure compatibility with chef-zero-15.0.11.

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG