### PR TITLE
CHEF-20340 - Fix dependency conflict with hashie for chef-zero-15.0.11 

### DIFF
--- a/kitchen-inspec.gemspec
+++ b/kitchen-inspec.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
   spec.add_dependency "inspec", "~> 6.0" # for RC1 release 6.0 and the above has the licensing changes.
-  spec.add_dependency "hashie", ">= 3.4", "<= 5.0"
+  spec.add_dependency "hashie", ">= 3.4", "< 5.0"
 end


### PR DESCRIPTION
### Description

Resolving a dependency conflict in hashie gem to ensure compatibility with chef-zero-15.0.11.



### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG